### PR TITLE
Feature: execute Cairo programs on the RPC server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,11 @@ resolver = "2"
 members = ["madara-prover-rpc-client", "madara-prover-rpc-server", "stone-prover", "test-toolkit"]
 
 [workspace.dependencies]
+cairo-vm = { version = "0.9.0", features = ["lambdaworks-felt"] }
 prost = "0.12.1"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"
+thiserror = "1.0.50"
 tokio = { version = "1.34.0", features = ["macros", "process", "rt-multi-thread"] }
 tonic = "0.10.2"
 tonic-build = "0.10.2"

--- a/madara-prover-rpc-client/src/client.rs
+++ b/madara-prover-rpc-client/src/client.rs
@@ -1,8 +1,29 @@
 use tonic::codegen::tokio_stream::StreamExt;
-use tonic::Status;
+use tonic::{Status, Streaming};
 
 use crate::prover::prover_client::ProverClient;
-use crate::prover::{ProverRequest, ProverResponse};
+use crate::prover::{ExecutionRequest, ExecutionResponse, ProverRequest, ProverResponse};
+
+async fn wait_for_streamed_response<ResponseType>(
+    stream: Streaming<ResponseType>,
+) -> Result<ResponseType, Status> {
+    if let Some(response) = stream.take(1).next().await {
+        return response;
+    }
+
+    Err(Status::cancelled("server-side stream was dropped"))
+}
+
+pub async fn execute_program(
+    client: &mut ProverClient<tonic::transport::Channel>,
+    program_content: Vec<u8>,
+) -> Result<ExecutionResponse, Status> {
+    let request = tonic::Request::new(ExecutionRequest {
+        program: program_content,
+    });
+    let execution_stream = client.execute(request).await?.into_inner();
+    wait_for_streamed_response(execution_stream).await
+}
 
 pub async fn call_prover(
     client: &mut ProverClient<tonic::transport::Channel>,
@@ -20,9 +41,5 @@ pub async fn call_prover(
         prover_parameters,
     });
     let prover_stream = client.prove(request).await?.into_inner();
-    if let Some(prover_result) = prover_stream.take(1).next().await {
-        return prover_result;
-    }
-
-    Err(Status::cancelled("Server-side stream was dropped"))
+    wait_for_streamed_response(prover_stream).await
 }

--- a/madara-prover-rpc-server/Cargo.toml
+++ b/madara-prover-rpc-server/Cargo.toml
@@ -6,12 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cairo-vm = { version = "0.9.0", features = ["lambdaworks-felt"] }
 prost = { workspace = true }
 stone-prover = { path = "../stone-prover" }
+thiserror = {workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 serde_json = { workspace = true }
 tokio-stream = "0.1.14"
+bincode = "2.0.0-rc.3"
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/madara-prover-rpc-server/src/cairo.rs
+++ b/madara-prover-rpc-server/src/cairo.rs
@@ -1,0 +1,98 @@
+use bincode::error::EncodeError;
+use cairo_vm::air_public_input::PublicInputError;
+use cairo_vm::cairo_run::{
+    cairo_run, write_encoded_memory, write_encoded_trace, CairoRunConfig, EncodeTraceError,
+};
+use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
+use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
+use cairo_vm::vm::errors::trace_errors::TraceError;
+use cairo_vm::vm::runners::cairo_runner::CairoRunner;
+use cairo_vm::vm::vm_core::VirtualMachine;
+use thiserror::Error;
+
+use crate::prover::ExecutionResponse;
+
+#[derive(Error, Debug)]
+pub enum ExecutionError {
+    #[error("failed to generate public input")]
+    GeneratePublicInput(#[from] PublicInputError),
+    #[error("failed to generate program execution trace")]
+    GenerateTrace(#[from] TraceError),
+    #[error("failed to encode the VM memory in binary format")]
+    EncodeMemory(EncodeTraceError),
+    #[error("failed to encode the execution trace in binary format")]
+    EncodeTrace(EncodeTraceError),
+    #[error("failed to serialize the public input")]
+    SerializePublicInput(#[from] serde_json::Error),
+}
+
+/// An in-memory writer for bincode encoding.
+pub struct MemWriter {
+    pub buf: Vec<u8>,
+}
+
+impl MemWriter {
+    pub fn new() -> Self {
+        Self { buf: vec![] }
+    }
+}
+impl bincode::enc::write::Writer for MemWriter {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        self.buf.extend_from_slice(bytes);
+        Ok(())
+    }
+}
+
+/// Run a Cairo program in proof mode.
+///
+/// * `program_content`: Compiled program content.
+pub fn run_in_proof_mode(
+    program_content: &[u8],
+) -> Result<(CairoRunner, VirtualMachine), CairoRunError> {
+    let proof_mode = true;
+    let layout = "plain";
+
+    let cairo_run_config = CairoRunConfig {
+        entrypoint: "main",
+        trace_enabled: true,
+        relocate_mem: true,
+        layout,
+        proof_mode,
+        secure_run: None,
+        disable_trace_padding: false,
+    };
+
+    let mut hint_processor = BuiltinHintProcessor::new_empty();
+
+    cairo_run(program_content, &cairo_run_config, &mut hint_processor)
+}
+
+// TODO: split in two (extract data + format to ExecutionResponse)
+/// Extracts execution artifacts from the runner and VM (after execution).
+///
+/// * `cairo_runner` Cairo runner object.
+/// * `vm`: Cairo VM object.
+pub fn extract_run_artifacts(
+    cairo_runner: CairoRunner,
+    vm: VirtualMachine,
+) -> Result<ExecutionResponse, ExecutionError> {
+    let cairo_vm_public_input = cairo_runner.get_air_public_input(&vm)?;
+    let memory = cairo_runner.relocated_memory.clone();
+    let trace = vm.get_relocated_trace()?;
+
+    let mut memory_writer = MemWriter::new();
+    write_encoded_memory(&memory, &mut memory_writer).map_err(ExecutionError::EncodeMemory)?;
+    let memory_raw = memory_writer.buf;
+
+    let mut trace_writer = MemWriter::new();
+    write_encoded_trace(trace, &mut trace_writer).map_err(ExecutionError::EncodeTrace)?;
+    let trace_raw = trace_writer.buf;
+
+    let public_input_str = serde_json::to_string(&cairo_vm_public_input)?;
+
+    Ok(ExecutionResponse {
+        public_input: public_input_str,
+        memory: memory_raw,
+        trace: trace_raw,
+    })
+}

--- a/protocols/prover.proto
+++ b/protocols/prover.proto
@@ -2,7 +2,18 @@ syntax = "proto3";
 package prover;
 
 service Prover {
+    rpc Execute(ExecutionRequest) returns (stream ExecutionResponse);
     rpc Prove (ProverRequest) returns (stream ProverResponse);
+}
+
+message ExecutionRequest {
+  bytes program = 1;
+}
+
+message ExecutionResponse {
+  string public_input = 1;
+  bytes memory = 2;
+  bytes trace = 3;
 }
 
 message ProverRequest {

--- a/stone-prover/Cargo.toml
+++ b/stone-prover/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 description = "A Rust wrapper around StarkWare's Stone Prover."
 
 [dependencies]
+cairo-vm = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = "3.8.1"
-thiserror = "1.0.50"
+thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/stone-prover/tests/fixtures/fibonacci-no-hint/fibonacci.cairo
+++ b/stone-prover/tests/fixtures/fibonacci-no-hint/fibonacci.cairo
@@ -1,0 +1,18 @@
+func main() {
+    // Call fib(1, 1, 10).
+    let result: felt = fib(1, 1, 10);
+
+    // Make sure the 10th Fibonacci number is 144.
+    assert result = 144;
+    ret;
+}
+
+func fib(first_element, second_element, n) -> (res: felt) {
+    jmp fib_body if n != 0;
+    tempvar result = second_element;
+    return (second_element,);
+
+    fib_body:
+    tempvar y = first_element + second_element;
+    return fib(second_element, y, n - 1);
+}

--- a/stone-prover/tests/fixtures/fibonacci-no-hint/fibonacci_compiled.json
+++ b/stone-prover/tests/fixtures/fibonacci-no-hint/fibonacci_compiled.json
@@ -1,0 +1,799 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "compiler_version": "0.12.2",
+    "data": [
+        "0x40780017fff7fff",
+        "0x0",
+        "0x1104800180018000",
+        "0x4",
+        "0x10780017fff7fff",
+        "0x0",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0xa",
+        "0x1104800180018000",
+        "0x5",
+        "0x400680017fff7fff",
+        "0x90",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffd",
+        "0x5",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x482a7ffc7ffb8000",
+        "0x480a7ffc7fff8000",
+        "0x48127ffe7fff8000",
+        "0x482680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff7",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {
+            "<start>": "__start__:\nap += main.Args.SIZE + main.ImplicitArgs.SIZE;\ncall main;\n\n__end__:\njmp rel 0;\n"
+        },
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 2,
+                    "input_file": {
+                        "filename": "<start>"
+                    },
+                    "start_col": 1,
+                    "start_line": 2
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "__main__"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 10,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "<start>"
+                    },
+                    "start_col": 1,
+                    "start_line": 3
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "__main__"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 10,
+                    "end_line": 6,
+                    "input_file": {
+                        "filename": "<start>"
+                    },
+                    "start_col": 1,
+                    "start_line": 6
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 3
+                }
+            },
+            "8": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 31,
+                    "start_line": 3
+                }
+            },
+            "10": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 3
+                }
+            },
+            "12": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 3
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 37,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 3
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.result": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 6,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 6
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.result": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 8,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 7
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 11,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 11
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 12,
+                            "input_file": {
+                                "filename": "cairo_programs/fibonacci.cairo"
+                            },
+                            "start_col": 22,
+                            "start_line": 12
+                        },
+                        "While expanding the reference 'second_element' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 10
+                }
+            },
+            "20": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.result": 4,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 27,
+                            "end_line": 13,
+                            "input_file": {
+                                "filename": "cairo_programs/fibonacci.cairo"
+                            },
+                            "start_col": 13,
+                            "start_line": 13
+                        },
+                        "While expanding the reference 'second_element' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 10
+                }
+            },
+            "21": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.result": 4,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 30,
+                    "end_line": 13,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 13
+                }
+            },
+            "22": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 16
+                }
+            },
+            "23": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 30,
+                            "end_line": 17,
+                            "input_file": {
+                                "filename": "cairo_programs/fibonacci.cairo"
+                            },
+                            "start_col": 16,
+                            "start_line": 17
+                        },
+                        "While expanding the reference 'second_element' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 10
+                }
+            },
+            "24": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 33,
+                            "end_line": 17,
+                            "input_file": {
+                                "filename": "cairo_programs/fibonacci.cairo"
+                            },
+                            "start_col": 32,
+                            "start_line": 17
+                        },
+                        "While expanding the reference 'y' in:"
+                    ],
+                    "start_col": 13,
+                    "start_line": 16
+                }
+            },
+            "25": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 35,
+                    "start_line": 17
+                }
+            },
+            "27": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 17
+                }
+            },
+            "29": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 42,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 17
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.__end__": {
+            "pc": 4,
+            "type": "label"
+        },
+        "__main__.__start__": {
+            "pc": 0,
+            "type": "label"
+        },
+        "__main__.fib": {
+            "decorators": [],
+            "pc": 17,
+            "type": "function"
+        },
+        "__main__.fib.Args": {
+            "full_name": "__main__.fib.Args",
+            "members": {
+                "first_element": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "n": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "second_element": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.fib.ImplicitArgs": {
+            "full_name": "__main__.fib.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.fib.Return": {
+            "cairo_type": "(res: felt)",
+            "type": "type_definition"
+        },
+        "__main__.fib.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.fib.fib_body": {
+            "pc": 22,
+            "type": "label"
+        },
+        "__main__.fib.first_element": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.first_element",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-5), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.n": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.n",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "pc": 20,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.second_element": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.second_element",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 17,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.y": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "pc": 23,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 6,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 14,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 14,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 17,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 1
+                },
+                "pc": 20,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 1
+                },
+                "pc": 23,
+                "value": "[cast(ap + (-1), felt*)]"
+            }
+        ]
+    }
+}

--- a/stone-prover/tests/fixtures/fibonacci/fibonacci.cairo
+++ b/stone-prover/tests/fixtures/fibonacci/fibonacci.cairo
@@ -1,0 +1,39 @@
+// Copyright 2023 StarkWare Industries Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.starkware.co/open-source-license/
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+
+%builtins output
+func main(output_ptr: felt*) -> (output_ptr: felt*) {
+    alloc_locals;
+
+    // Load fibonacci_claim_index and copy it to the output segment.
+    local fibonacci_claim_index;
+    %{ ids.fibonacci_claim_index = program_input['fibonacci_claim_index'] %}
+
+    assert output_ptr[0] = fibonacci_claim_index;
+    let res = fib(1, 1, fibonacci_claim_index);
+    assert output_ptr[1] = res;
+
+    // Return the updated output_ptr.
+    return (output_ptr=&output_ptr[2]);
+}
+
+func fib(first_element: felt, second_element: felt, n: felt) -> felt {
+    if (n == 0) {
+        return second_element;
+    }
+
+    return fib(
+        first_element=second_element, second_element=first_element + second_element, n=n - 1
+    );
+}

--- a/stone-prover/tests/fixtures/fibonacci/fibonacci_compiled.json
+++ b/stone-prover/tests/fixtures/fibonacci/fibonacci_compiled.json
@@ -1,0 +1,857 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output"
+    ],
+    "compiler_version": "0.12.0",
+    "data": [
+        "0x40780017fff7fff",
+        "0x1",
+        "0x1104800180018000",
+        "0x4",
+        "0x10780017fff7fff",
+        "0x0",
+        "0x40780017fff7fff",
+        "0x1",
+        "0x400380007ffd8000",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480a80007fff8000",
+        "0x1104800180018000",
+        "0x6",
+        "0x400280017ffd7fff",
+        "0x482680017ffd8000",
+        "0x2",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffd",
+        "0x4",
+        "0x480a7ffc7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x480a7ffc7fff8000",
+        "0x482a7ffc7ffb8000",
+        "0x482680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff9",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {
+            "<start>": "__start__:\nap += main.Args.SIZE + main.ImplicitArgs.SIZE;\ncall main;\n\n__end__:\njmp rel 0;\n"
+        },
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 2,
+                    "input_file": {
+                        "filename": "<start>"
+                    },
+                    "start_col": 1,
+                    "start_line": 2
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "__main__"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 10,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "<start>"
+                    },
+                    "start_col": 1,
+                    "start_line": 3
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "__main__"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 10,
+                    "end_line": 6,
+                    "input_file": {
+                        "filename": "<start>"
+                    },
+                    "start_col": 1,
+                    "start_line": 6
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 17
+                }
+            },
+            "8": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 77,
+                            "end_line": 21,
+                            "input_file": {
+                                "filename": "fibonacci.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 21
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 50,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 23
+                }
+            },
+            "9": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 20,
+                    "end_line": 24,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 19,
+                    "start_line": 24
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 24,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 22,
+                    "start_line": 24
+                }
+            },
+            "13": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 20,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 46,
+                            "end_line": 24,
+                            "input_file": {
+                                "filename": "fibonacci.cairo"
+                            },
+                            "start_col": 25,
+                            "start_line": 24
+                        },
+                        "While expanding the reference 'fibonacci_claim_index' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 20
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 24,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 15,
+                    "start_line": 24
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0,
+                        "__main__.main.res": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 25,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 25
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0,
+                        "__main__.main.res": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 38,
+                    "end_line": 28,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 28
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0,
+                        "__main__.main.res": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 28,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 28
+                }
+            },
+            "20": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 3,
+                        "__main__.fib.n": 5,
+                        "__main__.fib.second_element": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 32,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 32
+                }
+            },
+            "22": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 3,
+                        "__main__.fib.n": 5,
+                        "__main__.fib.second_element": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 30,
+                            "end_line": 33,
+                            "input_file": {
+                                "filename": "fibonacci.cairo"
+                            },
+                            "start_col": 16,
+                            "start_line": 33
+                        },
+                        "While expanding the reference 'second_element' in:"
+                    ],
+                    "start_col": 31,
+                    "start_line": 31
+                }
+            },
+            "23": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 3,
+                        "__main__.fib.n": 5,
+                        "__main__.fib.second_element": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 33,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 33
+                }
+            },
+            "24": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 3,
+                        "__main__.fib.n": 5,
+                        "__main__.fib.second_element": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 37,
+                            "end_line": 37,
+                            "input_file": {
+                                "filename": "fibonacci.cairo"
+                            },
+                            "start_col": 23,
+                            "start_line": 37
+                        },
+                        "While expanding the reference 'second_element' in:"
+                    ],
+                    "start_col": 31,
+                    "start_line": 31
+                }
+            },
+            "25": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 3,
+                        "__main__.fib.n": 5,
+                        "__main__.fib.second_element": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 84,
+                    "end_line": 37,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 54,
+                    "start_line": 37
+                }
+            },
+            "26": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 3,
+                        "__main__.fib.n": 5,
+                        "__main__.fib.second_element": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 93,
+                    "end_line": 37,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 88,
+                    "start_line": 37
+                }
+            },
+            "28": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 3,
+                        "__main__.fib.n": 5,
+                        "__main__.fib.second_element": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 6,
+                    "end_line": 38,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 36
+                }
+            },
+            "30": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 3,
+                        "__main__.fib.n": 5,
+                        "__main__.fib.second_element": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 38,
+                    "input_file": {
+                        "filename": "fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 36
+                }
+            }
+        }
+    },
+    "hints": {
+        "8": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "code": "ids.fibonacci_claim_index = program_input['fibonacci_claim_index']",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.fibonacci_claim_index": 1,
+                        "__main__.main.output_ptr": 0
+                    }
+                }
+            }
+        ]
+    },
+    "identifiers": {
+        "__main__.__end__": {
+            "pc": 4,
+            "type": "label"
+        },
+        "__main__.__start__": {
+            "pc": 0,
+            "type": "label"
+        },
+        "__main__.fib": {
+            "decorators": [],
+            "pc": 20,
+            "type": "function"
+        },
+        "__main__.fib.Args": {
+            "full_name": "__main__.fib.Args",
+            "members": {
+                "first_element": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "n": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "second_element": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.fib.ImplicitArgs": {
+            "full_name": "__main__.fib.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.fib.Return": {
+            "cairo_type": "felt",
+            "type": "type_definition"
+        },
+        "__main__.fib.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.fib.first_element": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.first_element",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 20,
+                    "value": "[cast(fp + (-5), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.n": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.n",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 20,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.second_element": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.second_element",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 20,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 6,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "(output_ptr: felt*)",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 1
+        },
+        "__main__.main.fibonacci_claim_index": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.fibonacci_claim_index",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "pc": 8,
+                    "value": "[cast(fp, felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 6,
+                    "value": "[cast(fp + (-3), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.res": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.res",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 16,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 6,
+                "value": "[cast(fp + (-3), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 1
+                },
+                "pc": 8,
+                "value": "[cast(fp, felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 16,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 20,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 20,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 20,
+                "value": "[cast(fp + (-3), felt*)]"
+            }
+        ]
+    }
+}

--- a/stone-prover/tests/fixtures/hello-world/hello_world.cairo
+++ b/stone-prover/tests/fixtures/hello-world/hello_world.cairo
@@ -1,0 +1,6 @@
+func main() {
+    tempvar x = 10;
+    tempvar y = x + x;
+    tempvar z = y * y + x;
+    return ();
+}

--- a/stone-prover/tests/fixtures/hello-world/hello_world_compiled.json
+++ b/stone-prover/tests/fixtures/hello-world/hello_world_compiled.json
@@ -1,0 +1,273 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "compiler_version": "0.12.2",
+    "data": [
+        "0x480680017fff8000",
+        "0xa",
+        "0x48307fff7fff8000",
+        "0x48507fff7fff8000",
+        "0x48307ffd7fff8000",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 19,
+                    "end_line": 2,
+                    "input_file": {
+                        "filename": "../madara-prover-api/stone-prover/tests/fixtures/hello-world/hello_world.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 2
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.x": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "../madara-prover-api/stone-prover/tests/fixtures/hello-world/hello_world.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 3
+                }
+            },
+            "3": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.x": 0,
+                        "__main__.main.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "../madara-prover-api/stone-prover/tests/fixtures/hello-world/hello_world.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 4
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp0": 2,
+                        "__main__.main.x": 0,
+                        "__main__.main.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 26,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "../madara-prover-api/stone-prover/tests/fixtures/hello-world/hello_world.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 4
+                }
+            },
+            "5": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp0": 2,
+                        "__main__.main.x": 0,
+                        "__main__.main.y": 1,
+                        "__main__.main.z": 3
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "../madara-prover-api/stone-prover/tests/fixtures/hello-world/hello_world.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.main": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.__temp0": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.__temp0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 3
+                    },
+                    "pc": 4,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.x": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "pc": 2,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.y": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "pc": 3,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.z": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.z",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 4
+                    },
+                    "pc": 5,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 1
+                },
+                "pc": 2,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 2
+                },
+                "pc": 3,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 3
+                },
+                "pc": 4,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 4
+                },
+                "pc": 5,
+                "value": "[cast(ap + (-1), felt*)]"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Users can now run any Cairo program using the RPC client + server. The new `Execute` RPC endpoint sends a program to the server and returns execution traces.
The server now relies on the `cairo-vm` crate to run programs in proof mode and then extract artifacts (public input, memory and trace).