### PR TITLE
Internal: isolate test utilities in a dedicated crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = ["madara-prover-rpc-client", "madara-prover-rpc-server", "stone-prover"]
+members = ["madara-prover-rpc-client", "madara-prover-rpc-server", "stone-prover", "test-toolkit"]
 
 [workspace.dependencies]
 prost = "0.12.1"

--- a/madara-prover-rpc-server/Cargo.toml
+++ b/madara-prover-rpc-server/Cargo.toml
@@ -16,3 +16,6 @@ tokio-stream = "0.1.14"
 [build-dependencies]
 tonic-build = { workspace = true }
 
+[dev-dependencies]
+test-toolkit = { path = "../test-toolkit" }
+

--- a/stone-prover/Cargo.toml
+++ b/stone-prover/Cargo.toml
@@ -11,3 +11,5 @@ tempfile = "3.8.1"
 thiserror = "1.0.50"
 tokio = { workspace = true }
 
+[dev-dependencies]
+test-toolkit = { path = "../test-toolkit" }

--- a/stone-prover/src/models.rs
+++ b/stone-prover/src/models.rs
@@ -110,8 +110,8 @@ pub struct Proof {
 
 #[cfg(test)]
 mod tests {
-    use crate::toolkit::load_fixture;
     use std::path::Path;
+    use test_toolkit::load_fixture;
 
     use super::*;
 

--- a/stone-prover/src/prover.rs
+++ b/stone-prover/src/prover.rs
@@ -225,8 +225,10 @@ pub async fn run_prover_async(
 mod test {
     use tempfile::NamedTempFile;
 
+    use test_toolkit::get_fixture_path;
+
     use crate::models::{PrivateInput, Proof};
-    use crate::toolkit::{get_fixture_path, read_json_from_file};
+    use crate::toolkit::read_json_from_file;
 
     use super::*;
 

--- a/stone-prover/src/toolkit.rs
+++ b/stone-prover/src/toolkit.rs
@@ -1,9 +1,5 @@
-#[cfg(test)]
-use std::fs;
 use std::fs::File;
 use std::path::Path;
-#[cfg(test)]
-use std::path::PathBuf;
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -25,17 +21,4 @@ pub fn write_json_to_file<T: Serialize, P: AsRef<Path>>(
     let mut file = File::create(path)?;
     serde_json::to_writer(&mut file, &obj)?;
     Ok(())
-}
-
-#[cfg(test)]
-pub fn get_fixture_path(filename: &str) -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures")
-        .join(filename)
-}
-
-#[cfg(test)]
-pub fn load_fixture(filename: &str) -> String {
-    let fixture_path = get_fixture_path(filename);
-    fs::read_to_string(fixture_path).expect("Failed to read the fixture file")
 }

--- a/test-toolkit/Cargo.toml
+++ b/test-toolkit/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test-toolkit"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test-toolkit/src/lib.rs
+++ b/test-toolkit/src/lib.rs
@@ -1,0 +1,12 @@
+use std::path::{Path, PathBuf};
+
+pub fn get_fixture_path(filename: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../stone-prover/tests/fixtures")
+        .join(filename)
+}
+
+pub fn load_fixture(filename: &str) -> String {
+    let fixture_path = get_fixture_path(filename);
+    std::fs::read_to_string(fixture_path).expect("Failed to read the fixture file")
+}


### PR DESCRIPTION
Problem: test fixture utils are not available to the client/server crates.

Solution: extract these functions from the stone-prover crate and add a new project-wide crate as dev dependency for all crates in the project.