### PR TITLE
Fix: use the right layout to run Starknet programs

### DIFF
--- a/madara-prover-rpc-server/src/cairo.rs
+++ b/madara-prover-rpc-server/src/cairo.rs
@@ -50,7 +50,7 @@ pub fn run_in_proof_mode(
     program_content: &[u8],
 ) -> Result<(CairoRunner, VirtualMachine), CairoRunError> {
     let proof_mode = true;
-    let layout = "plain";
+    let layout = "starknet_with_keccak";
 
     let cairo_run_config = CairoRunConfig {
         entrypoint: "main",


### PR DESCRIPTION
Use the `starknet_with_keccak` layout instead of the `plain` layout.