### PR TITLE
 Feature: return complete proof object from prover RPC

### DIFF
--- a/integration-tests/tests/test_integration.rs
+++ b/integration-tests/tests/test_integration.rs
@@ -93,7 +93,7 @@ mod tests {
 
         assert!(result.is_ok(), "{:?}", result);
 
-        let prover_response = result.unwrap();
-        assert_eq!(prover_response.proof_hex, test_case.proof.proof_hex);
+        let proof = result.unwrap();
+        assert_eq!(proof.proof_hex, test_case.proof.proof_hex);
     }
 }

--- a/protocols/prover.proto
+++ b/protocols/prover.proto
@@ -26,5 +26,5 @@ message ProverRequest {
 }
 
 message ProverResponse {
-    string proof_hex = 1;
+    string proof = 1;
 }


### PR DESCRIPTION
Problem: the server only returns the proof from the prover output and
discards other data. We may want to keep the prover output unmodified
when passing it to the verifier.

Solution: return a serialized `Proof` object directly.