### PR TITLE
Feature: add missing fields to Proof struct

### DIFF
--- a/madara-prover-common/src/models.rs
+++ b/madara-prover-common/src/models.rs
@@ -120,9 +120,19 @@ impl<'a> TryFrom<cairo_vm::air_public_input::PublicInput<'a>> for PublicInput {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct ProofVersion {
+    commit_hash: String,
+    proof_hash: String,
+    statement_name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Proof {
-    // Note: we only map output fields for now
+    pub private_input: PrivateInput,
     pub proof_hex: String,
+    pub proof_parameters: ProverParameters,
+    pub prover_config: ProverConfig,
+    pub public_input: PublicInput,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Problem: we were only returning the `proof_hex` field in `Proof` structs, but the verifier also requires the prover inputs and configuration.

Solution: add missing fields to the model.