### PR TITLE
Fix: use unary RPCs instead of server-side streaming

### DIFF
--- a/protocols/prover.proto
+++ b/protocols/prover.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 package prover;
 
 service Prover {
-    rpc Execute(ExecutionRequest) returns (stream ExecutionResponse);
-    rpc Prove (ProverRequest) returns (stream ProverResponse);
+    rpc Execute(ExecutionRequest) returns (ExecutionResponse);
+    rpc Prove (ProverRequest) returns (ProverResponse);
     rpc ExecuteAndProve(ExecutionRequest) returns (ProverResponse);
 }
 


### PR DESCRIPTION
Problem: server-side streaming does not actually change anything related
to connection management (gRPC manages one long-lived HTTP/2 connection for all
RPCs). Therefore, unary RPCs are simpler and a better fit.